### PR TITLE
feat: Add mock data for get-family-members endpoint

### DIFF
--- a/wiremock/mappings/get-family-members/bad-request.json
+++ b/wiremock/mappings/get-family-members/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-family-members",
+    "queryParameters": {
+      "pin": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'pin' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/get-family-members/get-family-members-empty.json
+++ b/wiremock/mappings/get-family-members/get-family-members-empty.json
@@ -1,0 +1,23 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-family-members",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "33333333333333"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "OK",
+      "message": "Успешно",
+      "members": []
+    }
+  }
+}

--- a/wiremock/mappings/get-family-members/get-family-members-multiple.json
+++ b/wiremock/mappings/get-family-members/get-family-members-multiple.json
@@ -1,0 +1,32 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-family-members",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "22222222222222"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "OK",
+      "message": "Успешно",
+      "members": [
+        {
+          "name": "Петров Петр Петрович",
+          "role": "Глава семьи"
+        },
+        {
+          "name": "Петрова Анна Ивановна",
+          "role": "Супруга"
+        }
+      ]
+    }
+  }
+}

--- a/wiremock/mappings/get-family-members/get-family-members-single.json
+++ b/wiremock/mappings/get-family-members/get-family-members-single.json
@@ -1,0 +1,28 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-family-members",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "11111111111111"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "OK",
+      "message": "Успешно",
+      "members": [
+        {
+          "name": "Иванов Иван Иванович",
+          "role": "Глава семьи"
+        }
+      ]
+    }
+  }
+}

--- a/wiremock/mappings/get-family-members/service-unavailable.json
+++ b/wiremock/mappings/get-family-members/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-family-members"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}


### PR DESCRIPTION
Creates five WireMock mapping files for the `/api/internal/v1/get-family-members` endpoint based on the provided Swagger definition.

The following scenarios are now mocked:
- 503 Service Unavailable
- 400 Bad Request (when 'pin' parameter is missing)
- 200 OK with a single member in the response
- 200 OK with two members in the response
- 200 OK with an empty members list in the response