### PR TITLE
feat: Add mocks for three core API endpoints

### DIFF
--- a/wiremock/mappings/passport-data-by-psn/bad-request.json
+++ b/wiremock/mappings/passport-data-by-psn/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/passport-data-by-psn",
+    "queryParameters": {
+      "series": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'series' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/passport-data-by-psn/passport-found.json
+++ b/wiremock/mappings/passport-data-by-psn/passport-found.json
@@ -1,0 +1,51 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/passport-data-by-psn",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "66666666666666"
+      },
+      "series": {
+        "equalTo": "AN"
+      },
+      "number": {
+        "equalTo": "123456"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "pin": "{{request.query.pin}}",
+      "surname": "Асанов",
+      "name": "Асан",
+      "patronymic": "Асанович",
+      "patronymicIsAbsent": "false",
+      "dateOfBirth": "1990-01-15",
+      "nationality": "Кыргыз",
+      "gender": "Мужской",
+      "voidan": "false",
+      "issuedDate": "2020-05-10",
+      "expiryDate": "2030-05-09",
+      "familyStatus": "Женат/Замужем",
+      "addressRegion": "г. Бишкек",
+      "addressDistrict": "Ленинский район",
+      "addressStreet": "ул. Киевская",
+      "addressHouse": "100",
+      "addressApartment": "1",
+      "regionId": "41701000000000",
+      "districtId": "41701401000000",
+      "cityId": 1,
+      "streetId": 123,
+      "houseId": 456
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/passport-data-by-psn/passport-not-found.json
+++ b/wiremock/mappings/passport-data-by-psn/passport-not-found.json
@@ -1,0 +1,51 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/passport-data-by-psn",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "77777777777777"
+      },
+      "series": {
+        "equalTo": "ID"
+      },
+      "number": {
+        "equalTo": "654321"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "pin": "{{request.query.pin}}",
+      "surname": null,
+      "name": null,
+      "patronymic": null,
+      "patronymicIsAbsent": "true",
+      "dateOfBirth": null,
+      "nationality": null,
+      "gender": null,
+      "voidan": "true",
+      "issuedDate": null,
+      "expiryDate": null,
+      "familyStatus": null,
+      "addressRegion": null,
+      "addressDistrict": null,
+      "addressStreet": null,
+      "addressHouse": null,
+      "addressApartment": null,
+      "regionId": null,
+      "districtId": null,
+      "cityId": null,
+      "streetId": null,
+      "houseId": null
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/passport-data-by-psn/service-unavailable.json
+++ b/wiremock/mappings/passport-data-by-psn/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/passport-data-by-psn"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for three API endpoints based on user-provided Swagger screenshots:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn

For each endpoint, a standard set of scenarios has been mocked:
- Service Unavailable (503)
- Bad Request (400)
- Successful response with data (200 OK)
- Successful response indicating data was not found (200 OK)