### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/search-pin-all/bad-request.json
+++ b/wiremock/mappings/search-pin-all/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-pin-all",
+    "queryParameters": {
+      "pin": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'pin' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/search-pin-all/multiple-properties.json
+++ b/wiremock/mappings/search-pin-all/multiple-properties.json
@@ -1,0 +1,41 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-pin-all",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "99999999999999"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "Propcode": "1-02-03-0004-0056",
+        "Address": "г. Ош, ул. Ленина, 12",
+        "Owner": "Саматов Самат Саматович",
+        "Pin": "{{request.query.pin}}",
+        "DocNum": "OSH-111222",
+        "REG_DATE": "2015-11-10",
+        "TERM_DATE": ""
+      },
+      {
+        "Propcode": "1-02-03-0004-0057",
+        "Address": "г. Ош, ул. Курманжан Датка, 200",
+        "Owner": "Саматов Самат Саматович",
+        "Pin": "{{request.query.pin}}",
+        "DocNum": "OSH-333444",
+        "REG_DATE": "2018-03-25",
+        "TERM_DATE": ""
+      }
+    ],
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/search-pin-all/no-properties.json
+++ b/wiremock/mappings/search-pin-all/no-properties.json
@@ -1,0 +1,19 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-pin-all",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "00000000000000"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": []
+  }
+}

--- a/wiremock/mappings/search-pin-all/service-unavailable.json
+++ b/wiremock/mappings/search-pin-all/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-pin-all"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}

--- a/wiremock/mappings/search-pin-all/single-property.json
+++ b/wiremock/mappings/search-pin-all/single-property.json
@@ -1,0 +1,32 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-pin-all",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "88888888888888"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "Propcode": "4-01-01-0001-0123",
+        "Address": "г. Каракол, ул. Абдрахманова, 120",
+        "Owner": "Темиров Темир Темирович",
+        "Pin": "{{request.query.pin}}",
+        "DocNum": "IK-555444",
+        "REG_DATE": "2019-11-20",
+        "TERM_DATE": ""
+      }
+    ],
+    "transformers": [
+      "response-template"
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for four API endpoints based on user-provided Swagger screenshots:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn
- /api/internal/v1/search-pin-all

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability.