### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/search-all-by-prop-code/bad-request.json
+++ b/wiremock/mappings/search-all-by-prop-code/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-prop-code",
+    "queryParameters": {
+      "propCode": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'propCode' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/search-all-by-prop-code/property-found.json
+++ b/wiremock/mappings/search-all-by-prop-code/property-found.json
@@ -1,0 +1,28 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-prop-code",
+    "queryParameters": {
+      "propCode": {
+        "equalTo": "PROP123"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "materialsten": "Кирпич",
+      "ploshad_stroenia": "120.5",
+      "ploshad_zem_uchastka": "600",
+      "vid_zem_uchastka": "Садовый участок",
+      "god_postroiki": "2010",
+      "formaobstvenosti": "Частная",
+      "document_prava": "Договор купли-продажи",
+      "formaIspolzovania": "Индивидуальное жилищное строительство"
+    }
+  }
+}

--- a/wiremock/mappings/search-all-by-prop-code/property-not-found.json
+++ b/wiremock/mappings/search-all-by-prop-code/property-not-found.json
@@ -1,0 +1,28 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-prop-code",
+    "queryParameters": {
+      "propCode": {
+        "equalTo": "PROP999"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "materialsten": null,
+      "ploshad_stroenia": null,
+      "ploshad_zem_uchastka": null,
+      "vid_zem_uchastka": null,
+      "god_postroiki": null,
+      "formaobstvenosti": null,
+      "document_prava": null,
+      "formaIspolzovania": null
+    }
+  }
+}

--- a/wiremock/mappings/search-all-by-prop-code/service-unavailable.json
+++ b/wiremock/mappings/search-all-by-prop-code/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-prop-code"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for five API endpoints based on user-provided Swagger screenshots:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn
- /api/internal/v1/search-pin-all
- /api/internal/v1/search-all-by-prop-code

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability.