### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/search-all-by-full-name/bad-request.json
+++ b/wiremock/mappings/search-all-by-full-name/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-full-name",
+    "queryParameters": {
+      "firstname": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'firstname' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/search-all-by-full-name/multiple-properties.json
+++ b/wiremock/mappings/search-all-by-full-name/multiple-properties.json
@@ -1,0 +1,41 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-full-name",
+    "queryParameters": {
+      "surname": {
+        "equalTo": "Петров"
+      },
+      "firstname": {
+        "equalTo": "Петр"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "Propcode": "6-02-01-0002-0111",
+        "Address": "г. Жалал-Абад, ул. Токтогула, 15",
+        "Owner": "Петров Петр",
+        "Pin": "10202198005678",
+        "DocNum": "JA-123123",
+        "REG_DATE": "2010-06-12",
+        "TERM_DATE": ""
+      },
+      {
+        "Propcode": "6-02-01-0002-0112",
+        "Address": "г. Жалал-Абад, ул. Ленина, 30",
+        "Owner": "Петров Петр",
+        "Pin": "10202198005678",
+        "DocNum": "JA-456456",
+        "REG_DATE": "2015-08-01",
+        "TERM_DATE": ""
+      }
+    ]
+  }
+}

--- a/wiremock/mappings/search-all-by-full-name/no-properties.json
+++ b/wiremock/mappings/search-all-by-full-name/no-properties.json
@@ -1,0 +1,22 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-full-name",
+    "queryParameters": {
+      "surname": {
+        "equalTo": "Сидоров"
+      },
+      "firstname": {
+        "equalTo": "Сидор"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": []
+  }
+}

--- a/wiremock/mappings/search-all-by-full-name/service-unavailable.json
+++ b/wiremock/mappings/search-all-by-full-name/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-full-name"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}

--- a/wiremock/mappings/search-all-by-full-name/single-property.json
+++ b/wiremock/mappings/search-all-by-full-name/single-property.json
@@ -1,0 +1,32 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/search-all-by-full-name",
+    "queryParameters": {
+      "surname": {
+        "equalTo": "Иванов"
+      },
+      "firstname": {
+        "equalTo": "Иван"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "Propcode": "5-01-01-0001-0555",
+        "Address": "г. Бишкек, ул. Исанова, 5",
+        "Owner": "Иванов Иван",
+        "Pin": "20101199001234",
+        "DocNum": "BISH-987654",
+        "REG_DATE": "2021-01-15",
+        "TERM_DATE": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for six API endpoints based on user-provided Swagger screenshots:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn
- /api/internal/v1/search-pin-all
- /api/internal/v1/search-all-by-prop-code
- /api/internal/v1/search-all-by-full-name

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability.