### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/get-death-act-data-by-pin/bad-request.json
+++ b/wiremock/mappings/get-death-act-data-by-pin/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-death-act-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'pin' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/get-death-act-data-by-pin/found.json
+++ b/wiremock/mappings/get-death-act-data-by-pin/found.json
@@ -1,0 +1,36 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-death-act-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "11111111111111"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "actDate": "2023-10-26",
+      "actNo": "12345",
+      "actOrgan": "ЗАГС г. Бишкек",
+      "docDate": "2023-10-26",
+      "docSeries": "V-ДР",
+      "docNo": "987654",
+      "certificate": "V-ДР №987654",
+      "pin": "{{request.query.pin}}",
+      "lastName": "Усопший",
+      "firstName": "Пример",
+      "patronymic": "Тестович",
+      "deathDate": "2023-10-25",
+      "deathTime": "14:30:00"
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/get-death-act-data-by-pin/not-found.json
+++ b/wiremock/mappings/get-death-act-data-by-pin/not-found.json
@@ -1,0 +1,36 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-death-act-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "22222222222222"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "actDate": null,
+      "actNo": null,
+      "actOrgan": null,
+      "docDate": null,
+      "docSeries": null,
+      "docNo": null,
+      "certificate": null,
+      "pin": "{{request.query.pin}}",
+      "lastName": null,
+      "firstName": null,
+      "patronymic": null,
+      "deathDate": null,
+      "deathTime": null
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/get-death-act-data-by-pin/service-unavailable.json
+++ b/wiremock/mappings/get-death-act-data-by-pin/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-death-act-data-by-pin"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for seven API endpoints based on user-provided Swagger screenshots:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn
- /api/internal/v1/search-pin-all
- /api/internal/v1/search-all-by-prop-code
- /api/internal/v1/search-all-by-full-name
- /api/internal/v1/get-death-act-data-by-pin

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability.