### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/get-data-by-pin/bad-request.json
+++ b/wiremock/mappings/get-data-by-pin/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "faultCode": 400,
+      "faultString": "Параметр 'pin' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/get-data-by-pin/found.json
+++ b/wiremock/mappings/get-data-by-pin/found.json
@@ -1,0 +1,40 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "11111111111111"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "pin": "{{request.query.pin}}",
+      "name": "Иван",
+      "surname": "Иванов",
+      "patronymic": "Иванович",
+      "gender": "Мужской",
+      "maritalStatusId": 2,
+      "maritalStatus": "Женат/Замужем",
+      "nationalityId": 1,
+      "nationality": "Кыргыз",
+      "citizenshipId": 1,
+      "citizenship": "Кыргызская Республика",
+      "pinBlocked": false,
+      "pinGenerationDate": "1990-01-01",
+      "photo": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      "deathDate": null,
+      "faultCode": 0,
+      "faultString": "OK"
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/get-data-by-pin/not-found-error.json
+++ b/wiremock/mappings/get-data-by-pin/not-found-error.json
@@ -1,0 +1,40 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-data-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "22222222222222"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "pin": "{{request.query.pin}}",
+      "name": null,
+      "surname": null,
+      "patronymic": null,
+      "gender": null,
+      "maritalStatusId": null,
+      "maritalStatus": null,
+      "nationalityId": null,
+      "nationality": null,
+      "citizenshipId": null,
+      "citizenship": null,
+      "pinBlocked": null,
+      "pinGenerationDate": null,
+      "photo": null,
+      "deathDate": null,
+      "faultCode": 1,
+      "faultString": "Данные не найдены"
+    },
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/get-data-by-pin/service-unavailable.json
+++ b/wiremock/mappings/get-data-by-pin/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-data-by-pin"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "faultCode": 503,
+      "faultString": "Сервис временно недоступен"
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for eight API endpoints based on user-provided Swagger screenshots.

The following endpoints are now mocked:
- /api/internal/v1/get-family-members
- /api/internal/v1/get-address-fact
- /api/internal/v1/passport-data-by-psn
- /api/internal/v1/search-pin-all
- /api/internal/v1/search-all-by-prop-code
- /api/internal/v1/search-all-by-full-name
- /api/internal/v1/get-death-act-data-by-pin
- /api/internal/v1/get-data-by-pin

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability.