### PR TITLE
feat: Add mocks for all core API endpoints

### DIFF
--- a/wiremock/mappings/get-patents-by-pin/bad-request.json
+++ b/wiremock/mappings/get-patents-by-pin/bad-request.json
@@ -1,0 +1,22 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-patents-by-pin",
+    "queryParameters": {
+      "dateCurrent": {
+        "absent": true
+      }
+    }
+  },
+  "response": {
+    "status": 400,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "BAD_REQUEST",
+      "message": "Параметр 'dateCurrent' является обязательным"
+    }
+  }
+}

--- a/wiremock/mappings/get-patents-by-pin/multiple-documents.json
+++ b/wiremock/mappings/get-patents-by-pin/multiple-documents.json
@@ -1,0 +1,43 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-patents-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "22222222222222"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "id": 201,
+        "createDate": "2022-05-20T11:00:00",
+        "pin": "{{request.query.pin}}",
+        "tin": "{{request.query.pin}}",
+        "objectAddress": "г. Ош, ул. Ленина, 50",
+        "finalAmount": 7500,
+        "isArenda": true,
+        "isFinalAmount": true,
+        "parentId": 0,
+        "isArendaAmount": true
+      },
+      {
+        "id": 202,
+        "createDate": "2023-03-15T15:30:00",
+        "dateTo": "2024-03-14T23:59:59",
+        "statusId": 1,
+        "policyCost": "1200.00",
+        "tin": "{{request.query.pin}}"
+      }
+    ],
+    "transformers": [
+      "response-template"
+    ]
+  }
+}

--- a/wiremock/mappings/get-patents-by-pin/no-documents.json
+++ b/wiremock/mappings/get-patents-by-pin/no-documents.json
@@ -1,0 +1,19 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-patents-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "33333333333333"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": []
+  }
+}

--- a/wiremock/mappings/get-patents-by-pin/service-unavailable.json
+++ b/wiremock/mappings/get-patents-by-pin/service-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-patents-by-pin"
+  },
+  "response": {
+    "status": 503,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": {
+      "code": "SERVICE_UNAVAILABLE",
+      "message": "Сервис временно недоступен"
+    }
+  }
+}

--- a/wiremock/mappings/get-patents-by-pin/single-patent.json
+++ b/wiremock/mappings/get-patents-by-pin/single-patent.json
@@ -1,0 +1,35 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/internal/v1/get-patents-by-pin",
+    "queryParameters": {
+      "pin": {
+        "equalTo": "11111111111111"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json; charset=UTF-8"
+    },
+    "jsonBody": [
+      {
+        "id": 101,
+        "createDate": "2023-01-10T10:00:00",
+        "pin": "{{request.query.pin}}",
+        "tin": "{{request.query.pin}}",
+        "objectAddress": "г. Бишкек, ул. Токтогула, 1",
+        "finalAmount": 5000,
+        "isArenda": false,
+        "isFinalAmount": true,
+        "parentId": 0,
+        "isArendaAmount": false
+      }
+    ],
+    "transformers": [
+      "response-template"
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces WireMock mappings for ten API endpoints based on user-provided Swagger screenshots.

For each endpoint, a standard set of scenarios has been mocked, including successful responses, bad requests, and service unavailability. This completes the full set of mocks for the service.