### PR TITLE
feat: Add mock data for asb_address endpoint

### DIFF
--- a/mocks/asb-address/bad_request.json
+++ b/mocks/asb-address/bad_request.json
@@ -1,0 +1,10 @@
+{
+  "code": 400,
+  "message": "Bad Request",
+  "errors": [
+    {
+      "field": "pin",
+      "message": "The pin field is required."
+    }
+  ]
+}

--- a/mocks/asb-address/no_addresses.json
+++ b/mocks/asb-address/no_addresses.json
@@ -1,0 +1,7 @@
+{
+  "addressArray": [],
+  "error": "true",
+  "address": "Адрес не найден",
+  "pension": "false",
+  "dateCreated": "2023-10-27T10:00:00Z"
+}

--- a/mocks/asb-address/one_address.json
+++ b/mocks/asb-address/one_address.json
@@ -1,0 +1,20 @@
+{
+  "addressArray": [
+    {
+      "countryId": "KG",
+      "regionId": "01",
+      "districtId": "02",
+      "cityId": "03",
+      "villageId": "04",
+      "streetId": "05",
+      "houseTxt": "123",
+      "flatTxt": "45",
+      "code": "720000",
+      "post": "Главпочтамт"
+    }
+  ],
+  "error": "false",
+  "address": "г. Бишкек, ул. Киевская, д. 123, кв. 45",
+  "pension": "false",
+  "dateCreated": "2023-10-27T10:00:00Z"
+}

--- a/mocks/asb-address/service_unavailable.json
+++ b/mocks/asb-address/service_unavailable.json
@@ -1,0 +1,4 @@
+{
+  "code": 503,
+  "message": "Service Unavailable"
+}

--- a/mocks/asb-address/two_addresses.json
+++ b/mocks/asb-address/two_addresses.json
@@ -1,0 +1,32 @@
+{
+  "addressArray": [
+    {
+      "countryId": "KG",
+      "regionId": "01",
+      "districtId": "02",
+      "cityId": "03",
+      "villageId": "04",
+      "streetId": "05",
+      "houseTxt": "123",
+      "flatTxt": "45",
+      "code": "720000",
+      "post": "Главпочтамт"
+    },
+    {
+      "countryId": "KG",
+      "regionId": "02",
+      "districtId": "03",
+      "cityId": "04",
+      "villageId": "05",
+      "streetId": "06",
+      "houseTxt": "456",
+      "flatTxt": "78",
+      "code": "720001",
+      "post": "Филиал 1"
+    }
+  ],
+  "error": "false",
+  "address": "г. Бишкек, ул. Киевская, д. 123, кв. 45; г. Ош, ул. Ленина, д. 456, кв. 78",
+  "pension": "false",
+  "dateCreated": "2023-10-27T10:00:00Z"
+}


### PR DESCRIPTION
This commit adds a new set of mock data files for the `asb_address` API endpoint based on the provided Swagger documentation.

The new mock files are located in the `mocks/asb-address/` directory and cover the following scenarios:
- 503 Service Unavailable
- 400 Bad Request
- 200 OK with a single address
- 200 OK with two addresses
- 200 OK with no addresses